### PR TITLE
typos and Correct type name

### DIFF
--- a/docs/2.md
+++ b/docs/2.md
@@ -21,7 +21,7 @@ We will use something called `GQL` or **G**raphQL **Q**uery **L**anguage. We def
 
 ```
 type Query {
-  hello: string
+  hello: String
 }
 ```
 
@@ -68,7 +68,7 @@ type Person {
   id: ID!
   name: String,
   address: String,
-  married: Boolean
+  speaker: Boolean
 }
 ```
 
@@ -201,7 +201,7 @@ input ProductInput {
 As you can see it's pretty much identical to our `type Person` and NO we can't use that one, we need to define something of type `input` like above. Let's add a `addPerson` property to our Schema:
 
 ```
-input ProductInput {
+input PersonInput {
   id: ID!
   name: String,
   address: String,


### PR DESCRIPTION
As the scalar type is **String**
I think the Person type should be consistent with the examples (married <-> speaker)
There is no ProductInput in the Person example