### PR TITLE
docs(1.md): fix variable and text typos

### DIFF
--- a/docs/1.md
+++ b/docs/1.md
@@ -24,26 +24,26 @@ With GraphQL you are able to ask for exactly the data you want at almost any dep
 
 **Let's take an example**
 
-Imagine having a normal REST API and you want all the `orders`, `order items` and what `products` were ordered then you would probably pose queries like this:
+Imagine having a normal REST API and you want all the `orders`, `order items` and what `products` were ordered using `order_id` then you would probably pose queries like this:
 
+To get informations about an order,
 ```
-order-api/orders/{order id}
-```
-to get an order detail
-
-To get the order items you would have to call something like this:
-
-```
-order-api/order-items/{order id}
+order-api/orders/{order_id}
 ```
 
-To know what products someone bought you would have to do this
+To get the order items, you would have to call something like this:
 
 ```
-order-api/order-items/{order id}/product
+order-api/order-items/{order_id}
 ```
 
-The exact implementation may wary but the point is that it is more than one REST request for all the data you need to present at a page. You could obviously solve that and build specific REST endpoints that builds that particular view. 
+To know what products someone bought, you would have to do this
+
+```
+order-api/order-items/{order_id}/product
+```
+
+The exact implementation may vary but the point is that it is more than one REST request for all the data you need to present at a page. You could obviously solve that and build specific REST endpoints that builds that particular view. 
 
 OR you use GraphQL and all you have to type is this:
 


### PR DESCRIPTION
We assume that {order_id} is an appropriate variable name to hold any order id requested. Based on some of the rules of variable definition: `a variable name should not contain space between its words.`. Therefore changing {order id} to {order_id} goes with the rule.
Changed `wary` -> `vary` in `The exact implementation may wary but the point is ...`